### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY requirements.txt /usr/src/app/
 COPY setup.py /usr/src/app/
 
 RUN pip3 install --no-cache-dir -r requirements.txt && \
-    pip3 install uwsgi ipython && \
-    pip3 install -e /usr/src/app
+    pip3 install --no-cache-dir uwsgi ipython && \
+    pip3 install --no-cache-dir -e /usr/src/app
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>